### PR TITLE
Add instructions on booting up the app for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # jeopardixir
 Jeopardy app made with Elixir to study
 
-# Start with Docker
+# Developing Jeopardixir
 
-docker-compose up phoenix
+Requirements:
+- Docker
+- Install Elixir (see: https://elixir-lang.org/install.html)
+- Ensure you have Elixir installed by running `elixir -v`
+- Install Phoenix (see: https://hexdocs.pm/phoenix/installation.html#elixir-1-6-or-later)
+- Install Node JS (eg. `brew install node`)
+
+To get started with the app, run:
+
+1. `git clone git@github.com:arielj/jeopardixir.git`
+2. `mix deps.get`
+3. `docker-compose up`


### PR DESCRIPTION
Had a chance to _finally_ pull the repo today and ran into slight gotcha which @arielj's advice of `mix deps.get` helped.

Updating the README doc to help others who may be interested in developing with this project.
