### PR TITLE
Custom basic code to load env variables from .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+PGUSER=username
+PGPASSWORD=password
+PGDATABASE=jeopardixir_dev
+PGHOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
-
+node_modules
 .env

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,15 +1,31 @@
 use Mix.Config
 
-# Configure your database
-# config :jeopardixir, Jeopardixir.Repo,
-#   username: "postgres",
-#   password: "123456",
-#   database: "jeopardixir_dev",
-#   hostname: "localhost",
-#   show_sensitive_data_on_connection_error: true,
-#   pool_size: 10
+defmodule ReadDotenv do
+  def put_env_var(line) do
+    [var_name, var_value] = String.split(line, "=", parts: 2)
+    unless System.get_env(var_name) do
+      System.put_env(var_name, var_value)
+    end
+  end
 
-# For docker
+  def put_env_vars(content) do
+    Enum.each(String.split(content, "\n"), fn line -> put_env_var(line) end)
+  end
+
+  def load! do
+    env_path = ".env"
+    if File.exists?(env_path) do
+      case File.read(env_path) do
+        {:ok, content} -> put_env_vars(content)
+      end
+    end
+  end
+end
+
+ReadDotenv.load!
+
+# Configure your database
+# Set the env variable in a .env file, use .env.sample as an example
 config :jeopardixir, Jeopardixir.Repo,
   username: System.get_env("PGUSER"),
   password: System.get_env("PGPASSWORD"),

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,9 +2,11 @@ use Mix.Config
 
 defmodule ReadDotenv do
   def put_env_var(line) do
-    [var_name, var_value] = String.split(line, "=", parts: 2)
-    unless System.get_env(var_name) do
-      System.put_env(var_name, var_value)
+    if line != "" do
+      [var_name, var_value] = String.split(line, "=", parts: 2)
+      unless System.get_env(var_name) do
+        System.put_env(var_name, var_value)
+      end
     end
   end
 


### PR DESCRIPTION
@cleicar I tried many things but I still was not able to get the env variables ready during the execution of the config/* files so I ended up making this basic script that reads the `.env` file if present and then update the env variables if not already set.

With this script we can use both the app directly or inside docker.

This is an alternative solution to https://github.com/arielj/jeopardixir/issues/8

In the future we can improve the parsing of the .env file, but for now it's enough for what we need.