### PR TITLE
Load .env variables in config/config.exs so it works for all environments and load `.env.test` too

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 PGUSER=username
 PGPASSWORD=password
-PGDATABASE=jeopardixir_dev
+PGDATABASE_DEV=jeopardixir_dev
+PGDATABASE_TEST=jeopardixir_test
 PGHOST=localhost

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,4 @@
 PGUSER=username
 PGPASSWORD=password
-PGDATABASE_DEV=jeopardixir_dev
-PGDATABASE_TEST=jeopardixir_test
+PGDATABASE=jeopardixir_dev
 PGHOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ npm-debug.log
 /priv/static/
 node_modules
 .env
+.env.test
+.env.dev

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,32 @@
 # General application configuration
 use Mix.Config
 
+defmodule ReadDotenv do
+  def put_env_var(line) do
+    if line != "" do
+      [var_name, var_value] = String.split(line, "=", parts: 2)
+      unless System.get_env(var_name) do
+        System.put_env(var_name, var_value)
+      end
+    end
+  end
+
+  def put_env_vars(content) do
+    Enum.each(String.split(content, "\n"), fn line -> put_env_var(line) end)
+  end
+
+  def load! do
+    env_path = ".env"
+    if File.exists?(env_path) do
+      case File.read(env_path) do
+        {:ok, content} -> put_env_vars(content)
+      end
+    end
+  end
+end
+
+ReadDotenv.load!
+
 config :jeopardixir,
   ecto_repos: [Jeopardixir.Repo]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,9 +22,16 @@ defmodule ReadDotenv do
   end
 
   def load! do
-    env_path = ".env"
-    if File.exists?(env_path) do
-      case File.read(env_path) do
+    file_path = ".env"
+    if File.exists?(file_path) do
+      case File.read(file_path) do
+        {:ok, content} -> put_env_vars(content)
+      end
+    end
+
+    env_file_path = ".env.#{Mix.env()}"
+    if File.exists?(env_file_path) do
+      case File.read(env_file_path) do
         {:ok, content} -> put_env_vars(content)
       end
     end
@@ -32,6 +39,8 @@ defmodule ReadDotenv do
 end
 
 ReadDotenv.load!
+
+IO.puts System.get_env("PGDATABASE")
 
 config :jeopardixir,
   ecto_repos: [Jeopardixir.Repo]

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,7 @@ defmodule ReadDotenv do
 
   # load the .env* files
   def load! do
-    [".env", ".env.#{Mix.env()}"]
+    [".env.#{Mix.env()}", ".env"]
     |> Enum.each(&load_file/1)
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,39 +8,39 @@
 use Mix.Config
 
 defmodule ReadDotenv do
-  def put_env_var(line) do
-    if line != "" do
-      [var_name, var_value] = String.split(line, "=", parts: 2)
-      unless System.get_env(var_name) do
-        System.put_env(var_name, var_value)
-      end
+  # processes a line setting the env variable only if not present
+  defp put_env_var(""), do: "" # do nothing if line is empty
+  defp put_env_var(line) do
+    [var_name, var_value] = String.split(line, "=", parts: 2)
+    unless System.get_env(var_name) do
+      System.put_env(var_name, var_value)
     end
   end
 
-  def put_env_vars(content) do
-    Enum.each(String.split(content, "\n"), fn line -> put_env_var(line) end)
+  # parse and process each line
+  defp put_env_vars(content) do
+    content
+    |> String.split("\n")
+    |> Enum.each(&put_env_var/1)
   end
 
-  def load! do
-    file_path = ".env"
+  # check if file existes and process its content
+  defp load_file(file_path) do
     if File.exists?(file_path) do
       case File.read(file_path) do
         {:ok, content} -> put_env_vars(content)
       end
     end
+  end
 
-    env_file_path = ".env.#{Mix.env()}"
-    if File.exists?(env_file_path) do
-      case File.read(env_file_path) do
-        {:ok, content} -> put_env_vars(content)
-      end
-    end
+  # load the .env* files
+  def load! do
+    [".env", ".env.#{Mix.env()}"]
+    |> Enum.each(&load_file/1)
   end
 end
 
 ReadDotenv.load!
-
-IO.puts System.get_env("PGDATABASE")
 
 config :jeopardixir,
   ecto_repos: [Jeopardixir.Repo]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,37 +1,11 @@
 use Mix.Config
 
-defmodule ReadDotenv do
-  def put_env_var(line) do
-    if line != "" do
-      [var_name, var_value] = String.split(line, "=", parts: 2)
-      unless System.get_env(var_name) do
-        System.put_env(var_name, var_value)
-      end
-    end
-  end
-
-  def put_env_vars(content) do
-    Enum.each(String.split(content, "\n"), fn line -> put_env_var(line) end)
-  end
-
-  def load! do
-    env_path = ".env"
-    if File.exists?(env_path) do
-      case File.read(env_path) do
-        {:ok, content} -> put_env_vars(content)
-      end
-    end
-  end
-end
-
-ReadDotenv.load!
-
 # Configure your database
 # Set the env variable in a .env file, use .env.sample as an example
 config :jeopardixir, Jeopardixir.Repo,
   username: System.get_env("PGUSER"),
   password: System.get_env("PGPASSWORD"),
-  database: System.get_env("PGDATABASE"),
+  database: System.get_env("PGDATABASE_DEV"),
   hostname: System.get_env("PGHOST"),
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ use Mix.Config
 config :jeopardixir, Jeopardixir.Repo,
   username: System.get_env("PGUSER"),
   password: System.get_env("PGPASSWORD"),
-  database: System.get_env("PGDATABASE_DEV"),
+  database: System.get_env("PGDATABASE"),
   hostname: System.get_env("PGHOST"),
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,7 +8,7 @@ use Mix.Config
 config :jeopardixir, Jeopardixir.Repo,
   username: System.get_env("PGUSER"),
   password: System.get_env("PGPASSWORD"),
-  database: System.get_env("PGDATABASE"),
+  database: "#{System.get_env("PGDATABASE")}_#{System.get_env("MIX_TEST_PARTITION")}",
   hostname: System.get_env("PGHOST"),
   pool: Ecto.Adapters.SQL.Sandbox
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,7 +8,7 @@ use Mix.Config
 config :jeopardixir, Jeopardixir.Repo,
   username: System.get_env("PGUSER"),
   password: System.get_env("PGPASSWORD"),
-  database: System.get_env("PGDATABASE_TEST"),
+  database: System.get_env("PGDATABASE"),
   hostname: System.get_env("PGHOST"),
   pool: Ecto.Adapters.SQL.Sandbox
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,10 +6,10 @@ use Mix.Config
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 config :jeopardixir, Jeopardixir.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "jeopardixir_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "localhost",
+  username: System.get_env("PGUSER"),
+  password: System.get_env("PGPASSWORD"),
+  database: System.get_env("PGDATABASE_TEST"),
+  hostname: System.get_env("PGHOST"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,


### PR DESCRIPTION
The module that loads the env variables was implemented directly in config/dev.exs but that made the env variables unavailable for the test environment.

This PR moves the code to the config/config.exs file so the env variables are loaded before any app environment config is loaded. I also refactored it to be more `elixir` using pattern matching for the functions and the pipe operator instead of nesting function calls.

I also added another feature so we can have different env variables for dev and test: The loader first looks for a `.env.test` (or .env.dev depending on the current environment) file and then for a `.env` file that we can user for generic env variables.

So, for the database name, we can have:

```
# .env
PGUSER=postgres
PGPASSWORD=postgres
PGHOST=localhost
PGDATABASE=jeopardixir_dev
```

And we add a `.env.test` with:

```
# .env.test
PGDATABASE=jeopardixir_test
```

(if the `.env.dev` file or `.env.test` files are not present, it just ignores them)

Now, when running the tests, the loader will parse the `.env.test` file first, setting the database name, and then it will parse `.env` setting the rest except for the `PGDATABASE` variable because it was already set when processing the `.env.test` file.

When running the server, it will try to load `.env.dev` first, it skips that if not present. Then it loads the `.env` file setting all the generic variables.


This allows us to run the app and the tests with the correct configuration.