### PR TITLE
Remove/fix tests

### DIFF
--- a/test/jeopardixir/accounts_test.exs
+++ b/test/jeopardixir/accounts_test.exs
@@ -31,7 +31,6 @@ defmodule Jeopardixir.AccountsTest do
 
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Accounts.create_user(@valid_attrs)
-      assert user.encrypted_password == "some encrypted_password"
       assert user.username == "some username"
     end
 
@@ -42,7 +41,6 @@ defmodule Jeopardixir.AccountsTest do
     test "update_user/2 with valid data updates the user" do
       user = user_fixture()
       assert {:ok, %User{} = user} = Accounts.update_user(user, @update_attrs)
-      assert user.encrypted_password == "some updated encrypted_password"
       assert user.username == "some updated username"
     end
 

--- a/test/jeopardixir_web/controllers/user_controller_test.exs
+++ b/test/jeopardixir_web/controllers/user_controller_test.exs
@@ -4,19 +4,12 @@ defmodule JeopardixirWeb.UserControllerTest do
   alias Jeopardixir.Accounts
 
   @create_attrs %{encrypted_password: "some encrypted_password", username: "some username"}
-  @update_attrs %{encrypted_password: "some updated encrypted_password", username: "some updated username"}
+  # @update_attrs %{encrypted_password: "some updated encrypted_password", username: "some updated username"}
   @invalid_attrs %{encrypted_password: nil, username: nil}
 
   def fixture(:user) do
     {:ok, user} = Accounts.create_user(@create_attrs)
     user
-  end
-
-  describe "index" do
-    test "lists all users", %{conn: conn} do
-      conn = get(conn, Routes.user_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing Users"
-    end
   end
 
   describe "new user" do
@@ -30,59 +23,12 @@ defmodule JeopardixirWeb.UserControllerTest do
     test "redirects to show when data is valid", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
 
-      assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) == Routes.user_path(conn, :show, id)
-
-      conn = get(conn, Routes.user_path(conn, :show, id))
-      assert html_response(conn, 200) =~ "Show User"
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @invalid_attrs)
       assert html_response(conn, 200) =~ "New User"
     end
-  end
-
-  describe "edit user" do
-    setup [:create_user]
-
-    test "renders form for editing chosen user", %{conn: conn, user: user} do
-      conn = get(conn, Routes.user_path(conn, :edit, user))
-      assert html_response(conn, 200) =~ "Edit User"
-    end
-  end
-
-  describe "update user" do
-    setup [:create_user]
-
-    test "redirects when data is valid", %{conn: conn, user: user} do
-      conn = put(conn, Routes.user_path(conn, :update, user), user: @update_attrs)
-      assert redirected_to(conn) == Routes.user_path(conn, :show, user)
-
-      conn = get(conn, Routes.user_path(conn, :show, user))
-      assert html_response(conn, 200) =~ "some updated encrypted_password"
-    end
-
-    test "renders errors when data is invalid", %{conn: conn, user: user} do
-      conn = put(conn, Routes.user_path(conn, :update, user), user: @invalid_attrs)
-      assert html_response(conn, 200) =~ "Edit User"
-    end
-  end
-
-  describe "delete user" do
-    setup [:create_user]
-
-    test "deletes chosen user", %{conn: conn, user: user} do
-      conn = delete(conn, Routes.user_path(conn, :delete, user))
-      assert redirected_to(conn) == Routes.user_path(conn, :index)
-      assert_error_sent 404, fn ->
-        get(conn, Routes.user_path(conn, :show, user))
-      end
-    end
-  end
-
-  defp create_user(_) do
-    user = fixture(:user)
-    %{user: user}
   end
 end


### PR DESCRIPTION
This PR removes/fixes some tests that were created automatically and were not really needed because we don't have those actions in the controllers or we do different redirects.

This should close #14 and then we can add a CI job that runs the tests, though this is merged into PR 22, it is not created against the main branch so we need both merged.